### PR TITLE
Allow 'config.ru' path to be specified through an environment variable

### DIFF
--- a/bin/rash
+++ b/bin/rash
@@ -5,7 +5,8 @@ require 'pry'
 require 'rash/shell'
 
 ENV['RACK_ENV'] ||= 'development'
-Rack::Builder.parse_file('config.ru')
+config_ru_path = ENV.fetch('CONFIG_RU_PATH', 'config.ru')
+Rack::Builder.parse_file(config_ru_path)
 
 if ARGV.empty?
   Pry.start


### PR DESCRIPTION
You can't assume, at least in certain projects (not going to name names 😄), that the `config.ru` file is always in the root of a project. This allows the path to be specified through the `CONFIG_RU_PATH` environment variable. It defaults to `config.ru`.